### PR TITLE
Line emitter (#48)

### DIFF
--- a/OG/OG/ASTBuilding/TreeNodes/BodyNode and Statements/Statements/AssignmentNodes and extractors/MathAssignmentNode.cs
+++ b/OG/OG/ASTBuilding/TreeNodes/BodyNode and Statements/Statements/AssignmentNodes and extractors/MathAssignmentNode.cs
@@ -11,7 +11,9 @@ namespace OG.ASTBuilding.TreeNodes.MathNodes_and_extractors
 
         public MathAssignmentNode(IdNode id, MathNode value) : base(id, AssignmentType.VariableAssignmentNode)
         {
-            this.AssignedValue = value;
+
+            AssignedValue = value;
+
         }
 
         public override void Accept(IVisitor visitor)

--- a/OG/OG/AstVisiting/Visitor interfaces/Visitor interfaces/IVisitor.cs
+++ b/OG/OG/AstVisiting/Visitor interfaces/Visitor interfaces/IVisitor.cs
@@ -76,17 +76,16 @@ namespace OG.AstVisiting
         public Object Visit(IFunctionNode node);
         
         //Math
-        /*
+
         public Object Visit(AdditionNode node);
         public Object Visit(DivisionNode node);
         public Object Visit(InfixMathNode node);
         public Object Visit(MathIdNode node);
-        public Object Visit(MathNode node);
         public Object Visit(MultiplicationNode node);
         public Object Visit(PowerNode node);
         public Object Visit(SubtractionNode node);
         public Object Visit(TerminalMathNode node);
-         */
+
         
         //Point
         public Object Visit(PointFunctionCallNode node);
@@ -113,7 +112,6 @@ namespace OG.AstVisiting
         //
         public Object Visit(AstNode node);
         public Object Visit(DrawNode node);
-        public Object Visit(ExpressionNode node);
         public Object Visit(ProgramNode node);
         public Object Visit(ShapeNode node);
         public Object Visit(CoordinateXyValueNode node);

--- a/OG/OG/CodeGeneration/CurveEmitterVisitor.cs
+++ b/OG/OG/CodeGeneration/CurveEmitterVisitor.cs
@@ -1,0 +1,890 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Linq;
+using OG.ASTBuilding;
+using OG.ASTBuilding.Terminals;
+using OG.ASTBuilding.TreeNodes;
+using OG.ASTBuilding.TreeNodes.BodyNode_and_Statements;
+using OG.ASTBuilding.TreeNodes.BodyNode_and_Statements.Statements;
+using OG.ASTBuilding.TreeNodes.BodyNode_and_Statements.Statements.AssignmentNodes_and_extractors;
+using OG.ASTBuilding.TreeNodes.BodyNode_and_Statements.Statements.CommandNode;
+using OG.ASTBuilding.TreeNodes.BodyNode_and_Statements.Statements.DeclarationNodes_and_extractors;
+using OG.ASTBuilding.TreeNodes.BoolNodes_and_extractors;
+using OG.ASTBuilding.TreeNodes.FunctionCalls;
+using OG.ASTBuilding.TreeNodes.MathNodes_and_extractors;
+using OG.ASTBuilding.TreeNodes.PointReferences;
+using OG.ASTBuilding.TreeNodes.TerminalNodes;
+using OG.ASTBuilding.TreeNodes.WorkAreaNodes;
+using OG.AstVisiting;
+using OG.AstVisiting.Visitors;
+using Z.Expressions;
+
+namespace OG.CodeGeneration
+{
+    public class CurveEmitterVisitor : CodeEmitterErrorInheritor,  IVisitor, IGCodeStringEmitter
+    {
+        protected SymbolTable _symbolTable;
+        public IGCodeCommand ResultCommand { get; protected set; }
+
+        private PointReferenceCoordinateTracker ToPointGCodeCreater { get; set; }
+        private PointReferenceCoordinateTracker FromPointContainer { get; set; }
+        private SingleMathResultVisitor angleCont;
+        
+        
+        public CurveEmitterVisitor(SymbolTable symbolTable, List<SemanticError> errs):base(errs)
+        {
+            _symbolTable = symbolTable;
+            FromPointContainer = new PointReferenceCoordinateTracker(_symbolTable, errs);
+            ToPointGCodeCreater = new PointReferenceCoordinateTracker(_symbolTable, errs);
+            angleCont = new SingleMathResultVisitor(_symbolTable, errs);
+        }
+        
+        public object Visit(NumberNode node)
+        {
+            return node.NumberValue;
+        }
+        
+                
+        public string Emit()
+        {
+            Console.WriteLine(ResultCommand.CreateGCodeTextCommand());
+            return ResultCommand.CreateGCodeTextCommand().Replace(',', '.');
+        }
+        
+
+        private double EvaluateMathString(string expression)
+        {
+            return Eval.Execute<double>(expression);
+        }
+        
+        
+        /// <summary>
+        /// Sets up the emission of the GCode command of a curve. 
+        /// Creates Gcode arc command using G02 or G03 depending on angle. 
+        /// </summary>
+        /// <param name="node"></param>
+        /// <returns>Empty Object</returns>
+        public object Visit(CurveCommandNode node)
+        {
+            if (node?.To?.Count > 1)
+            {
+                SemanticErrors.Add(new SemanticError(node.Line, node .Column, "OG does not support to chaining in Curve commands."){IsFatal = false});
+            }
+            
+            node.Angle.Accept(angleCont);
+            node.To.First().Accept(ToPointGCodeCreater);
+            node.From.Accept(FromPointContainer);
+
+            Tuple<double, double> from = FromPointContainer.LastCalculatedCoordinateVals;
+            GCodeCommandText fromCommand = new GCodeCommandText($"G01 X{from.Item1} Y{from.Item2}\n");
+            
+            Tuple<double, double> to = ToPointGCodeCreater.LastCalculatedCoordinateVals;
+            double angle = angleCont.Result * (Math.PI / 180);
+            string curveCommandWord = "";
+
+            //Check for valid angle
+            if (angle < 90 && angle > -90)
+            {
+                //If angle is 0 then it is a line.
+                if (angle == 0)
+                {
+                    ResultCommand = new GCodeCommandText(fromCommand.CommandText + $"G01 X{from.Item1} Y{from.Item2}\n G01 X{to.Item1} Y{to.Item2}");
+                    return new object();
+                }
+
+                //Find out where to place circle.
+                if (angle < 0)
+                {
+                    curveCommandWord = "G03";
+                } else if (angle > 0)
+                {
+                    curveCommandWord = "G02";
+                }
+            }
+            else
+            {
+                SemanticErrors.Add(new SemanticError(node.Line, node.Column, "Angle is more than 90 degrees or less than -90 degrees."){IsFatal = true});
+                return null;
+            }
+
+            double radius = (Math.Sqrt(Math.Pow((from.Item1 - to.Item1), 2) + Math.Pow(from.Item2 - to.Item2,2))/2) //Pythagoras and distance
+                            / (Math.Cos(90 * Math.PI / 180) - (Math.Abs(angle) * Math.PI / 180));
+
+            Console.WriteLine("Radius: " + radius);
+            Console.WriteLine("ANGLE: " + angle);
+            Console.WriteLine("From:" + from.Item1   + "    "  + from.Item2);
+            ResultCommand = fromCommand + new GCodeCommandText(curveCommandWord + " " + $" X{to.Item1} Y{to.Item2} R{radius}");
+            return new object();
+        }
+        
+        #region Unused visit methods
+        
+
+        
+
+        public object Visit(AssignmentNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(BoolAssignmentNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(FunctionCallAssignNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(IdAssignNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(MathAssignmentNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(PointAssignmentNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(PropertyAssignmentNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(ParameterTypeNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(CommandNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+
+
+        public object Visit(DrawCommandNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(IterationNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(LineCommandNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(MovementCommandNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(NumberIterationNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(UntilFunctionCallNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(UntilNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(BoolDeclarationNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(DeclarationNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(NumberDeclarationNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(PointDeclarationNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(BoolExprIdNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(StatementNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(BodyNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(AndComparerNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(BoolComparerNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(BoolNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(BoolTerminalNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(EqualsComparerNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(GreaterThanComparerNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(LessThanComparerNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(MathComparerNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(NegationNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(OrComparerNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(BoolFunctionCallNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(FunctionCallNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(FunctionCallParameterNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(IFunctionCallNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(MathFunctionCallNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(ParameterNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(FunctionNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(IFunctionNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(AdditionNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(DivisionNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(InfixMathNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(MathIdNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(MathNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(MultiplicationNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(PowerNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(SubtractionNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(TerminalMathNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(PointFunctionCallNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(PointReferenceIdNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(PointReferenceNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(ShapeEndPointNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(ShapePointReference node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(ShapePointRefNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(ShapeStartPointNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(TuplePointNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+
+        public object Visit(FalseNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(IdNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+
+
+        public object Visit(TrueNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(MachineSettingNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(ModificationPropertyNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(SizePropertyNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(WorkAreaSettingNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(AstNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(DrawNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(ExpressionNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(ProgramNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(ShapeNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object Visit(CoordinateXyValueNode node)
+        {
+            throw new System.NotImplementedException();
+        }
+         #endregion
+    }
+
+    internal class SingleMathResultVisitor:IVisitor, ISemanticErrorable
+    {
+
+        
+        public double Result { get; private set; }
+        public List<SemanticError> SemanticErrors { get; set; }
+        private SymbolTable _symTable;
+        public string TopNode { get; set; }
+        public object Visit(NumberNode node)
+        {
+            Result = node.NumberValue;
+            return new object();
+        }
+
+        public SingleMathResultVisitor(SymbolTable symbolTable, List<SemanticError> errs)
+        {
+            SemanticErrors = errs;
+            _symTable = symbolTable;
+        }
+
+        #region Unused methods
+
+        
+
+        public object Visit(AssignmentNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(BoolAssignmentNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(FunctionCallAssignNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(IdAssignNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(MathAssignmentNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(PointAssignmentNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(PropertyAssignmentNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(ParameterTypeNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(CommandNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(CurveCommandNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(DrawCommandNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(IterationNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(LineCommandNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(MovementCommandNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(NumberIterationNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(UntilFunctionCallNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(UntilNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(BoolDeclarationNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(DeclarationNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(NumberDeclarationNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(PointDeclarationNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(BoolExprIdNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(StatementNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(BodyNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(AndComparerNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(BoolComparerNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(BoolNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(BoolTerminalNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(EqualsComparerNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(GreaterThanComparerNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(LessThanComparerNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(MathComparerNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(NegationNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(OrComparerNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(BoolFunctionCallNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(FunctionCallNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(FunctionCallParameterNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(IFunctionCallNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(MathFunctionCallNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(ParameterNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(FunctionNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(IFunctionNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(AdditionNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(DivisionNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(InfixMathNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(MathIdNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(MultiplicationNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(PowerNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(SubtractionNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(TerminalMathNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(PointFunctionCallNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(PointReferenceIdNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(PointReferenceNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(ShapeEndPointNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(ShapePointReference node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(ShapePointRefNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(ShapeStartPointNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(TuplePointNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(FalseNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(IdNode node)
+        {
+            throw new NotImplementedException();
+        }
+        
+        public object Visit(TrueNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(MachineSettingNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(ModificationPropertyNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(SizePropertyNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(WorkAreaSettingNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(AstNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(DrawNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(ProgramNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(ShapeNode node)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Visit(CoordinateXyValueNode node)
+        {
+            throw new NotImplementedException();
+        }
+        #endregion
+
+     
+    }
+
+    internal class PointReferenceCoordinateTracker : PointReferenceGCodeTextEmitter
+    {
+        
+        public Tuple<double, double> LastCalculatedCoordinateVals;
+        
+        public PointReferenceCoordinateTracker(SymbolTable table, List<SemanticError> errs) : base(table, errs)
+        {
+        }
+
+        public override void Visit(TuplePointNode node)
+        {
+            double xVal = EvaluateMathString(node.XValue.Value);
+            double yVal = EvaluateMathString(node.YValue.Value);
+
+            string formattedX = xVal.ToString(FormatStrings.DoubleFixedPoint).Replace(',','.');
+            string formattedY = yVal.ToString(FormatStrings.DoubleFixedPoint).Replace(',','.');
+            yVal = double.Parse(formattedY);
+            xVal = double.Parse(formattedX);
+            LastCalculatedCoordinateVals = new Tuple<double, double>(yVal, xVal);
+        }
+        
+    }
+
+   
+}

--- a/OG/OG/CodeGeneration/LineEmitterVisitor.cs
+++ b/OG/OG/CodeGeneration/LineEmitterVisitor.cs
@@ -2,6 +2,12 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Data;
+
+using OG.ASTBuilding;
+using OG.ASTBuilding.MathExpression;
+using OG.ASTBuilding.Terminals;
+using OG.ASTBuilding.TreeNodes.BodyNode_and_Statements.Statements.CommandNode;
+
 using System.Linq;
 using OG.ASTBuilding;
 using OG.ASTBuilding.MathExpression;
@@ -10,12 +16,14 @@ using OG.ASTBuilding.TreeNodes.BodyNode_and_Statements;
 using OG.ASTBuilding.TreeNodes.BodyNode_and_Statements.Statements;
 using OG.ASTBuilding.TreeNodes.BodyNode_and_Statements.Statements.CommandNode;
 using OG.ASTBuilding.TreeNodes.FunctionCalls;
+
 using OG.ASTBuilding.TreeNodes.MathNodes_and_extractors;
 using OG.ASTBuilding.TreeNodes.PointReferences;
 using OG.ASTBuilding.TreeNodes.TerminalNodes;
 using OG.AstVisiting;
 using OG.AstVisiting.Visitors;
 using Z.Expressions;
+
 
 namespace OG.CodeGeneration
 {
@@ -76,119 +84,10 @@ namespace OG.CodeGeneration
                 ToCommands.Add(ToPointGCodeCreater.ResultCommand);
             }
         }
+
     } 
     
-    public  class PointReferenceGCodeTextEmitter : CodeEmitterErrorInheritor, IPointReferenceNodeVisitor
-    {
-        protected SymbolTable _symbolTable;
-        public IGCodeCommand ResultCommand { get; protected set; }
 
-        public PointReferenceGCodeTextEmitter(SymbolTable table, List<SemanticError> errs):base(errs)
-        {
-            _symbolTable = table;
-        }
-        
-        /// <summary>
-        /// TODO: Create function call visitor that evaluates function calls.
-        /// </summary>
-        /// <param name="node"></param>
-        /// <exception cref="NotImplementedException"></exception>
-        public void Visit(PointFunctionCallNode node)
-        {
-            IEnumerable<ParameterNode> parameters = node.Parameters;
-            BodyNode body = node.Body;
-        }
-
-        /// <summary>
-        /// TODO: Somehow create a point from an ID node
-        /// </summary>
-        /// <param name="node"></param>
-        public void Visit(PointReferenceIdNode node)
-        {
-            
-            //if id is reference to another id, what then?
-            //if id is a tuple what then?
-            //if id is function call what then?
-            
-            /*
-             * if (node.isTuple){
-             *   string[] pair = node.text.remove( '(', ') ).split(.);
-             *   what if those strings are function calls??? FÅRK 
-             * }
-             *
-             */
-        }
-
-        
-        public void Visit(ShapeEndPointNode node)
-        {
-            throw new NotImplementedException();
-            //This is actually how we can find a shape end point
-            ShapeNode shape;
-            List<StatementNode> statements = shape.Body.StatementNodes;
-            statements.Reverse();
-            foreach (StatementNode statement in statements.Where(statement => statement.Type == StatementNode.StatementType.CommandNode))
-            {
-                try
-                {
-                    CommandNode command = (CommandNode) statement;
-                    if (command.TypeOfCommand == CommandNode.CommandType.MovementNode)
-                    {
-                        MovementCommandNode c = (MovementCommandNode) command;
-                        c.To.Last().Accept(this);
-                    }
-                }
-                catch (InvalidCastException e)
-                {
-                    continue;
-                }
-            }
-        }
-
-        public void Visit(ShapeStartPointNode node)
-        {
-            throw new NotImplementedException();
-            ShapeNode shape; //= _symbolTable.getShape(node.shapename.text).getnode;
-            List<StatementNode> statements = shape.Body.StatementNodes;
-            foreach (StatementNode statement in statements.Where(statement => statement.Type == StatementNode.StatementType.CommandNode))
-            {
-                try
-                {
-                    CommandNode command = (CommandNode) statement;
-                    if (command.TypeOfCommand == CommandNode.CommandType.MovementNode)
-                    {
-                        MovementCommandNode movement = (MovementCommandNode) command;
-                        movement.To.First().Accept(this);
-                    }
-                }
-                catch (InvalidCastException e)
-                {
-                    continue;
-                }
-            }
-        }
-
-     
-
-        public void Visit(TuplePointNode node)
-        {
-            double xVal = EvaluateMathString(node.XValue.Value);
-            double yVal = EvaluateMathString(node.YValue.Value);
-
-            string formattedX = xVal.ToString(FormatStrings.DoubleFixedPoint).Replace(',','.');
-            string formattedY = yVal.ToString(FormatStrings.DoubleFixedPoint).Replace(',','.');
-            yVal = double.Parse(formattedY);
-            xVal = double.Parse(formattedX);
-
-            ResultCommand = new GCodeCommandText($"G01 X{formattedX} Y{formattedY}\n");
-        }
-
-        protected double EvaluateMathString(string expression) 
-        {
-            return Eval.Execute<double>(expression);
-        }
-        
-    }
 
     /// <summary>
     /// Used to decide double precision formatting

--- a/OG/OG/CodeGeneration/PointReferenceGCodeTextEmitter.cs
+++ b/OG/OG/CodeGeneration/PointReferenceGCodeTextEmitter.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using OG.ASTBuilding;
+using OG.ASTBuilding.TreeNodes;
+using OG.ASTBuilding.TreeNodes.BodyNode_and_Statements;
+using OG.ASTBuilding.TreeNodes.BodyNode_and_Statements.Statements;
+using OG.ASTBuilding.TreeNodes.BodyNode_and_Statements.Statements.CommandNode;
+using OG.ASTBuilding.TreeNodes.FunctionCalls;
+using OG.ASTBuilding.TreeNodes.PointReferences;
+using OG.AstVisiting;
+using OG.AstVisiting.Visitors;
+using Z.Expressions;
+
+namespace OG.CodeGeneration
+{
+    public class PointReferenceGCodeTextEmitter : CodeEmitterErrorInheritor, IPointReferenceNodeVisitor
+    {
+        protected SymbolTable _symbolTable;
+        public IGCodeCommand ResultCommand { get; protected set; }
+
+
+        public PointReferenceGCodeTextEmitter(SymbolTable table, List<SemanticError> errs):base(errs)
+        {
+            _symbolTable = table;
+        }
+        
+        /// <summary>
+        /// TODO: Create function call visitor that evaluates function calls.
+        /// </summary>
+        /// <param name="node"></param>
+        /// <exception cref="NotImplementedException"></exception>
+        public void Visit(PointFunctionCallNode node)
+        {
+            IEnumerable<ParameterNode> parameters = node.Parameters;
+            BodyNode body = node.Body;
+        }
+
+        /// <summary>
+        /// TODO: Somehow create a point from an ID node
+        /// </summary>
+        /// <param name="node"></param>
+        public void Visit(PointReferenceIdNode node)
+        {
+            
+            //if id is reference to another id, what then?
+            //if id is a tuple what then?
+            //if id is function call what then?
+            
+            /*
+             * if (node.isTuple){
+             *   string[] pair = node.text.remove( '(', ') ).split(.);
+             *   what if those strings are function calls??? FÅRK 
+             * }
+             *
+             */
+        }
+
+        
+        public void Visit(ShapeEndPointNode node)
+        {
+            throw new NotImplementedException();
+            //This is actually how we can find a shape end point
+            ShapeNode shape;
+            List<StatementNode> statements = shape.Body.StatementNodes;
+            statements.Reverse();
+            foreach (StatementNode statement in statements.Where(statement => statement.Type == StatementNode.StatementType.CommandNode))
+            {
+                try
+                {
+                    CommandNode command = (CommandNode) statement;
+                    if (command.TypeOfCommand == CommandNode.CommandType.MovementNode)
+                    {
+                        MovementCommandNode c = (MovementCommandNode) command;
+                        c.To.Last().Accept(this);
+                    }
+                }
+                catch (InvalidCastException e)
+                {
+                    continue;
+                }
+            }
+        }
+
+        public void Visit(ShapeStartPointNode node)
+        {
+            throw new NotImplementedException();
+            ShapeNode shape; //= _symbolTable.getShape(node.shapename.text).getnode;
+            List<StatementNode> statements = shape.Body.StatementNodes;
+            foreach (StatementNode statement in statements.Where(statement => statement.Type == StatementNode.StatementType.CommandNode))
+            {
+                try
+                {
+                    CommandNode command = (CommandNode) statement;
+                    if (command.TypeOfCommand == CommandNode.CommandType.MovementNode)
+                    {
+                        MovementCommandNode movement = (MovementCommandNode) command;
+                        movement.To.First().Accept(this);
+                    }
+                }
+                catch (InvalidCastException e)
+                {
+                    continue;
+                }
+            }
+        }
+
+     
+
+        public virtual void Visit(TuplePointNode node)
+        {
+            double xVal = EvaluateMathString(node.XValue.Value);
+            double yVal = EvaluateMathString(node.YValue.Value);
+
+            string formattedX = xVal.ToString(FormatStrings.DoubleFixedPoint).Replace(',','.');
+            string formattedY = yVal.ToString(FormatStrings.DoubleFixedPoint).Replace(',','.');
+            yVal = double.Parse(formattedY);
+            xVal = double.Parse(formattedX);
+
+            
+
+            ResultCommand = new GCodeCommandText($"G01 X{formattedX} Y{formattedY}\n");
+        }
+
+        protected double EvaluateMathString(string expression) 
+        {
+            return Eval.Execute<double>(expression);
+        }
+        
+    }
+}

--- a/OG/OG/OGCompiler.cs
+++ b/OG/OG/OGCompiler.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+
+using System.Text.RegularExpressions;
+
 using System.Threading.Tasks;
 using Antlr4.Runtime;
 using OG.ASTBuilding;
@@ -18,50 +21,14 @@ using OG.Compiler;
 
 namespace OG
 {
-
-    public abstract class ErrorInheritorVisitor : IErrorable
-    {
-        
-        public ErrorInheritorVisitor(List<SemanticError> errs)
-        {
-            SemanticErrors = errs;
-        }
-        public List<SemanticError> SemanticErrors { get; set; }
-    }     
-    
-    
-    
     
     public class OGCompiler
     {
-        public static Dictionary<IdNode, FunctionNode> GlobalFunctionDeclarations = new Dictionary<IdNode, FunctionNode>();
         public static readonly Dictionary<IdNode, ShapeNode>    GlobalShapeDeclarations    = new Dictionary<IdNode, ShapeNode>();
         private static async Task Main(string[] args)
         {
             
-            double x1 = -0.000001, x2 = -1, y1 = 2.9999, y2 = 9999999.9999;
-            NumberNode x1Val = new NumberNode(x1);
-            NumberNode y1Val = new NumberNode(y2);
-            
-            NumberNode x2Val = new NumberNode(x2);
-            NumberNode y2Val = new NumberNode(y2);
-            List<PointReferenceNode> ToCommands = new List<PointReferenceNode>();
-
-            LineEmitterVisitor emitter = new LineEmitterVisitor(null, new List<SemanticError>());
-            
-            ToCommands.Add(new TuplePointNode("", x2Val, y2Val));
-            
-            
-            LineCommandNode lineCommand = new LineCommandNode(new TuplePointNode("",x1Val, y1Val), ToCommands);
-            lineCommand.Accept(emitter);
-            emitter.CodeGenerationNotification += (Console.WriteLine);
-            
-            
-            await File.WriteAllTextAsync("../../WriteText.txt", emitter.Emit());
-
-
-            
-            
+          
             // Handle args arguments in finished implementation, so its not hardcoded to testFile.og
             
             List<SemanticError> errors = new List<SemanticError>();

--- a/OG/Tests/CurveCodeGenerationTest.cs
+++ b/OG/Tests/CurveCodeGenerationTest.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+using OG.ASTBuilding;
+using OG.ASTBuilding.TreeNodes.BodyNode_and_Statements.Statements.CommandNode;
+using OG.ASTBuilding.TreeNodes.PointReferences;
+using OG.ASTBuilding.TreeNodes.TerminalNodes;
+using OG.AstVisiting;
+using OG.AstVisiting.Visitors;
+using OG.CodeGeneration;
+
+namespace Tests
+{
+    public class CurveCodeGenerationTest
+    {
+        private static Regex LineRegex { get; } = new Regex(@"^G01 X-?\d*\.{0,1}\d+ Y-?\d*\.{0,1}\d+$");
+        private static Regex ArcRegex { get; } = new Regex(@"^(G02|G03) X-?\d*\.{0,1}\d+ Y-?\d*\.{0,1}\d+ R-?\d*\.{0,1}\d+$");
+        private static Regex G02Regex { get; } = new Regex(@"^G02 X-?\d*\.{0,1}\d+ Y-?\d*\.{0,1}\d+ R-?\d*\.{0,1}\d+$");
+        private static Regex G03Regex { get; } = new Regex(@"^G03 X-?\d*\.{0,1}\d+ Y-?\d*\.{0,1}\d+ R-?\d*\.{0,1}\d+$");
+        
+        
+        [TestCase(45, -0.000001, -0.000001, 999999.9999,9999999.9999)]
+        [TestCase(-45,-0.01, -0.01, 0.01,0.001)]
+        [TestCase(-1,-0, -1000, 0, 0)]
+        [TestCase(1, -1000, 0,1,0)]
+        [TestCase(10, -1000, -1000,1,0)]
+        [TestCase(-10,1000, -1000,100,100)]
+        [TestCase(89.999,0, 0,99,99)]
+        [TestCase(-89.999,10, 10.10, 5,5)]
+        [TestCase(-0.999,0.0, 0.2, 999,9999)]
+        [TestCase(0.999,1, 1,0001, 1)]
+        public void Curve_Should_Match_RegexForG02Or (double angle, double x1, double y1, double x2, double y2)
+        {
+            NumberNode angleNode = new NumberNode(angle);
+            TuplePointNode fromNode = new TuplePointNode("", new NumberNode(x1), new NumberNode(y2));
+            List<PointReferenceNode> toNode = new List<PointReferenceNode>();
+            toNode.Add(new TuplePointNode("", new NumberNode(x2), new NumberNode(y2)));
+            
+            CurveCommandNode curveNode = new CurveCommandNode(fromNode, toNode, angleNode);
+            CurveEmitterVisitor curveEmitter = new CurveEmitterVisitor(new SymbolTable(), new List<SemanticError>());
+            Assert.DoesNotThrow(() =>
+            {
+                curveNode.Accept(curveEmitter);
+                Assert.IsTrue(curveEmitter.SemanticErrors.Count == 0);
+            });
+
+            string result = curveEmitter.Emit();
+            Assert.IsTrue(ArcRegex.IsMatch(result));
+        }
+    }
+}

--- a/OG/Tests/LineCodeGenerationTest.cs
+++ b/OG/Tests/LineCodeGenerationTest.cs
@@ -15,7 +15,7 @@ using OG.Compiler;
 
 namespace Tests
 {
-    public class CodeGenerationTest
+    public class LineCodeGenerationTest
     {
         private static Regex G01Regex { get; } = new Regex(@"^G01 X-?\d*\.{0,1}\d+ Y-?\d*\.{0,1}\d+$");
 
@@ -131,6 +131,8 @@ namespace Tests
                 Assert.IsTrue(G01Regex.IsMatch(str));
             });
         }
+        
+        
         
       
     }


### PR DESCRIPTION
* Implemented PointReferenceExtractor and node belonging to it

* Moved PointReferenceTypes to their own files

* Created Added way to return PointfunctionCallNodes in the PointRefExtractor.

* Moved files into more logical folder and created lovely pointReferenceExtraction method in PointReferenceNodeExtractor

* Corrections to PointReferenceExtractor. Can no extract PointReferenceNode from FromCommandContext

* PointReferenceNode extractor can now handle FromCommandContext

* Update PointReferenceNodeExtractor.cs

Added Visit methods for following context:

- FromWithNumberTupleContext

- FromWithIdContext

* Added abstract class TerminalMathNode and TerminalBoolNode.

NumberNode, MathFuncCallNode are now both TerminalMathNodes

TrueNode, FalseNode, BoolFunctionCallNode are now TerminalBoolNode

* REnamed TupleNode properties to make more sense

* Fixed requests

* Update ASTBuilderTest.cs

* Fixed point references and math func calls

* something are done

* fixed something

* Fixed drawcommands to have pointreferences instead of from nodes

* Renamed Valuenode --> Expressionnode to avoid future collissions

* Made some inheritance changes so that more math nodes that were atoms inherited from TerminalMathNode instead of MathNode

Created command node extractor and statementListExtractor and  Statement extractor.
Body now contains a list of statements.

* Fixed infinite recursion due to initialisation of command extractors on creation

* We now have a full program node builder

* Enforced From and To positions by adding constructor to MovementCommandNode

* Killing naming convention errors

* Removed unreachable statements and unused vars

* Moved function creation into function folder

* Logisk opdeling af nodes og extractors

* Mere inddeling i mapper

* Renaming and inddeling i mapper

* More folders!

* Less folders

* Corresponding namespaces and folders

We now have folders and matching namespaces.

Implemented TopNodeVisitor such that the AStBuilder container could become generic.

* Added ctor to astBuilderContainer so you can give a astBuilder as input

* bugfix

* .github file change

* da

* Lots of changes

* MOre line command

* Testing and found bugs in math evaluation from string. Solved by using other framework

* format fixes

* unused file deleted

* Added Semantic errorable abstract class so we can inherit semantic error lists.

* Added Regex testing for G01 commands

* Testing multiple to-chaining from tuples

* line emitter done

* CurveEmitter

* There we are

Co-authored-by: saxjax <saxjax@saxjax.dk>